### PR TITLE
Changed requirement for distribute to setuptools.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='slate',
       packages=find_packages('src'),
       package_dir={'': 'src'},
       requires=[pdfminer],
-      install_requires=['distribute', pdfminer],
+      install_requires=['setuptools', pdfminer],
       classifiers= [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
According to https://pythonhosted.org/distribute/ this package is obsolete and has been merged into setuptools.